### PR TITLE
Fix package name in pypi gh action; refs #10

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: release
-      url: https://pypi.org/p/memoria
+      url: https://pypi.org/p/memoria-search
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:


### PR DESCRIPTION
Couldn't snag the pypi project "memoria", had to use "memoria-search". The package publishes correctly regardless (because it goes off of the `pyproject.toml`), but the wrong value in the action config puts an incorrect hyperlink on the Actions page.